### PR TITLE
Fix rotation behavior

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ function drawImage(img: HTMLImageElement, width: number, height: number, offsetX
     if (degree !== 0) {
         ctx.translate(width/2 + offsetX + (canvas.width / 2 - width / 2), height/2 - offsetY + (canvas.width / 2 - height / 2));
         ctx.rotate(degree * Math.PI / 360);
-        ctx.drawImage(img, -(canvas.width / 2 - width / 2), -(canvas.width / 2 - height / 2), width, height);
+        ctx.drawImage(img, -(width/2), -(height/2), width, height);
     } else {
         ctx.drawImage(img, (canvas.width / 2 - width / 2) + offsetX, (canvas.width / 2 - height / 2) + offsetY, width, height);
     }


### PR DESCRIPTION
Looks like the CanvasRenderingContext2D is already at the center where you want, you only have to offset your image (When you draw image) so that the rotation is at the center of the image.

https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/rotate